### PR TITLE
Use custom errors and output more version info

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"runtime"
+
 	"github.com/spf13/cobra"
 )
 
@@ -37,7 +39,8 @@ message (notification) and validate are supported.
 See the README at https://github.com/arcanericky/pushover for
 more information. For details on Pushover, see
 https://pushover.net/.`,
-		Version: versionText,
+		Version: versionText + " " + runtime.GOOS + "/" +
+			runtime.GOARCH + " " + runtime.Version(),
 	}
 
 	addMessageCmd(rootCmd)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/arcanericky/pushover
 
-go 1.13
+go 1.13.x
 
 require (
 	github.com/spf13/cobra v0.0.5

--- a/message.go
+++ b/message.go
@@ -228,7 +228,7 @@ func MessageContext(ctx context.Context, request MessageRequest) (*MessageRespon
 
 	req, err := http.NewRequest(http.MethodPost, request.PushoverURL, requestData)
 	if err != nil {
-		return nil, ErrInvalidRequest
+		return nil, &ErrInvalidRequest{}
 	}
 
 	req = req.WithContext(ctx)
@@ -252,7 +252,7 @@ func MessageContext(ctx context.Context, request MessageRequest) (*MessageRespon
 	body := &bytes.Buffer{}
 	_, err = body.ReadFrom(resp.Body)
 	if err != nil {
-		return nil, ErrInvalidResponse
+		return nil, &ErrInvalidResponse{}
 	}
 
 	r.ResponseBody = body.String()
@@ -262,20 +262,20 @@ func MessageContext(ctx context.Context, request MessageRequest) (*MessageRespon
 	// Decode json response
 	var result map[string]interface{}
 	if e := json.NewDecoder(strings.NewReader(string(r.ResponseBody))).Decode(&result); e != nil {
-		return nil, ErrInvalidResponse
+		return nil, &ErrInvalidResponse{}
 	}
 
 	var ok bool
 
 	// Populate request status
 	if r.APIStatus, ok = mapKeyToInt(keyStatus, result); !ok {
-		return nil, ErrInvalidResponse
+		return nil, &ErrInvalidResponse{}
 	}
 	delete(result, keyStatus)
 
 	// Populate request ID
 	if r.Request, ok = result[keyRequest].(string); !ok {
-		return nil, ErrInvalidResponse
+		return nil, &ErrInvalidResponse{}
 	}
 	delete(result, keyRequest)
 

--- a/message_test.go
+++ b/message_test.go
@@ -142,7 +142,7 @@ func TestPushoverMessage(t *testing.T) {
 	// Invalid Pushover URL
 	request.PushoverURL = "\x7f"
 	r, e = MessageContext(context.TODO(), request)
-	if e != ErrInvalidRequest {
+	if _, ok := e.(*ErrInvalidRequest); !ok {
 		t.Error("Invalid Pushover URL")
 	}
 
@@ -201,28 +201,28 @@ func TestPushoverMessage(t *testing.T) {
 	// Invalid API Status in response
 	request.User = "failstatus"
 	r, e = Message(request)
-	if e != ErrInvalidResponse {
+	if _, ok := e.(*ErrInvalidResponse); !ok {
 		t.Error("Invalid API status in response")
 	}
 
 	// Invalid request ID in response
 	request.User = "failrequest"
 	r, e = Message(request)
-	if e != ErrInvalidResponse {
+	if _, ok := e.(*ErrInvalidResponse); !ok {
 		t.Error("Invalid request ID in response")
 	}
 
 	// Invalid json response
 	request.User = "failjson"
 	r, e = Message(request)
-	if e != ErrInvalidResponse {
+	if _, ok := e.(*ErrInvalidResponse); !ok {
 		t.Error("Invalid response JSON")
 	}
 
 	// Invalid body
 	request.User = "failbody"
 	r, e = Message(request)
-	if e != ErrInvalidResponse {
+	if _, ok := e.(*ErrInvalidResponse); !ok {
 		t.Error("Invalid response body")
 	}
 

--- a/pushover.go
+++ b/pushover.go
@@ -8,7 +8,6 @@
 package pushover
 
 import (
-	"errors"
 	"fmt"
 )
 
@@ -38,11 +37,19 @@ const (
 
 // ErrInvalidRequest indicates invalid request data
 // was sent to a library function
-var ErrInvalidRequest = errors.New("Invalid request")
+type ErrInvalidRequest struct{}
+
+func (ir *ErrInvalidRequest) Error() string {
+	return "Invalid request"
+}
 
 // ErrInvalidResponse indicates an invalid response body
 // was received from the Pushover API
-var ErrInvalidResponse = errors.New("Invalid response")
+type ErrInvalidResponse struct{}
+
+func (ir *ErrInvalidResponse) Error() string {
+	return "Invalid response"
+}
 
 var messagesURL = "https://api.pushover.net/1/messages.json"
 var validateURL = "https://api.pushover.net/1/users/validate.json"

--- a/validate.go
+++ b/validate.go
@@ -119,7 +119,7 @@ func ValidateContext(ctx context.Context, request ValidateRequest) (*ValidateRes
 	body := &bytes.Buffer{}
 	_, err = body.ReadFrom(resp.Body)
 	if err != nil {
-		return nil, ErrInvalidResponse
+		return nil, &ErrInvalidResponse{}
 	}
 
 	r.ResponseBody = body.String()
@@ -129,20 +129,20 @@ func ValidateContext(ctx context.Context, request ValidateRequest) (*ValidateRes
 	// Decode json response
 	var result map[string]interface{}
 	if e := json.NewDecoder(strings.NewReader(string(r.ResponseBody))).Decode(&result); e != nil {
-		return nil, ErrInvalidResponse
+		return nil, &ErrInvalidResponse{}
 	}
 
 	var ok bool
 
 	// Populate request status
 	if r.APIStatus, ok = mapKeyToInt(keyStatus, result); !ok {
-		return nil, ErrInvalidResponse
+		return nil, &ErrInvalidResponse{}
 	}
 	delete(result, keyStatus)
 
 	// Populate request ID
 	if r.Request, ok = result[keyRequest].(string); !ok {
-		return nil, ErrInvalidResponse
+		return nil, &ErrInvalidResponse{}
 	}
 	delete(result, keyRequest)
 

--- a/validate_test.go
+++ b/validate_test.go
@@ -136,21 +136,21 @@ func TestPushoverValidate(t *testing.T) {
 	// Invalid API Status in response
 	request.User = "failstatus"
 	r, e = Validate(request)
-	if e != ErrInvalidResponse {
+	if _, ok := e.(*ErrInvalidResponse); !ok {
 		t.Error("Invalid API status in response")
 	}
 
 	// Invalid request ID in response
 	request.User = "failrequest"
 	r, e = Validate(request)
-	if e != ErrInvalidResponse {
+	if _, ok := e.(*ErrInvalidResponse); !ok {
 		t.Error("Invalid request ID in response")
 	}
 
 	// Invalid json response
 	request.User = "failjson"
 	r, e = Validate(request)
-	if e != ErrInvalidResponse {
+	if _, ok := e.(*ErrInvalidResponse); !ok {
 		t.Error("Invalid response JSON")
 	}
 
@@ -166,7 +166,7 @@ func TestPushoverValidate(t *testing.T) {
 	// Invalid body
 	request.User = "failbody"
 	r, e = Validate(request)
-	if e != ErrInvalidResponse {
+	if _, ok := e.(*ErrInvalidResponse); !ok {
 		t.Error("Invalid response body")
 	}
 
@@ -175,5 +175,17 @@ func TestPushoverValidate(t *testing.T) {
 	r, e = Validate(request)
 	if e == nil {
 		t.Error("No API server")
+	}
+}
+
+func TestErrorTypes(t *testing.T) {
+	errRequest := &ErrInvalidRequest{}
+	if len(errRequest.Error()) == 0 {
+		t.Error("ErrInvalidRequest does not return string on Error()")
+	}
+
+	errResponse := &ErrInvalidResponse{}
+	if len(errResponse.Error()) == 0 {
+		t.Error("ErrInvalidResponse does not return string on Error()")
 	}
 }


### PR DESCRIPTION
* Use custom error types so users can use type assertions to determine the error
* Add additional output of OS, architecture and Go version on `--version` flag 