### PR TITLE
Enable callback option in CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,14 +100,17 @@ Usage:
   pushover message [flags]
 
 Flags:
+      --callback string      Optional callback URL
       --device string        Device name for message
+      --expire int16         Message expiration length
   -h, --help                 help for message
       --html                 Enable HTML formatting
       --image string         Image attachment
   -m, --message string       Notification message
       --monospace            Enable monospace formatting
-      --priority string      Message priority
+      --priority int8        Message priority
       --pushoverurl string   Pushover API URL
+      --retry int16          Retry interval
       --sound string         Name of a sound to override user's default
       --timestamp string     Unix timestamp for message
       --title string         Message title (if empty, uses app name)
@@ -115,7 +118,7 @@ Flags:
       --url string           Supplementary URL to show with the message
       --urltitle string      Title for the URL
   -u, --user string          User/Group key
-```
+  ```
 
 ## Contributing
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -7,6 +7,7 @@ import (
 )
 
 const (
+	optionCallback    = "callback"
 	optionDevice      = "device"
 	optionExpire      = "expire"
 	optionHTML        = "html"

--- a/cmd/message.go
+++ b/cmd/message.go
@@ -95,7 +95,7 @@ func intOptionToString(cmd *cobra.Command, option string, value int) string {
 func addMessageCmd(parentCmd *cobra.Command) {
 	const enable = "1"
 	var token, user, title, message, url, urlTitle, sound, device, image,
-		timestamp, pushoverURL, htmlField, monospaceValue string
+		timestamp, pushoverURL, htmlField, monospaceValue, callback string
 	var priority int8
 	var retry, expire int16
 	var html, monospace bool
@@ -152,6 +152,7 @@ Required options are:
 				Timestamp:   timestamp,
 				ImageReader: imageReader,
 				ImageName:   image,
+				Callback:    callback,
 			}
 
 			fmt.Println("Request")
@@ -193,6 +194,7 @@ Required options are:
 	messageCmd.Flags().Int16VarP(&retry, optionRetry, "", 0, "Retry interval")
 	messageCmd.Flags().Int16VarP(&expire, optionExpire, "", 0, "Message expiration length")
 	messageCmd.Flags().StringVarP(&timestamp, optionTimestamp, "", "", "Unix timestamp for message")
+	messageCmd.Flags().StringVarP(&callback, optionCallback, "", "", "Optional callback URL")
 
 	parentCmd.AddCommand(messageCmd)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/arcanericky/pushover
 
-go 1.13.x
+go 1.13
 
 require (
 	github.com/spf13/cobra v0.0.5


### PR DESCRIPTION
The callback parameter was enabled in the API in PR #10. This change exposes the callback option in the command-line interface with the `--callback` flag and passes it to the API. As with the other options, there are no checks against the format of the callback argument. It's simply passed to the API and then to Pushover. The callback is optional and only used by Pushover when the `--priority` option is set to `2`.